### PR TITLE
Fix unitialized values

### DIFF
--- a/src/MSQ_data_and_functions.hpp
+++ b/src/MSQ_data_and_functions.hpp
@@ -293,9 +293,9 @@ struct HarmonyType
 	int    harmony_step_chord_type[MAX_STEPS];
 	int    harmony_steps[MAX_STEPS]={1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1};  // initialize to a valid step degree
 };
-struct HarmonyType theHarmonyTypes[MAX_HARMONY_TYPES];
+struct HarmonyType theHarmonyTypes[MAX_HARMONY_TYPES] = {};
 
-struct HarmonyType theActiveHarmonyType;
+struct HarmonyType theActiveHarmonyType = {};
 
 int  circle_of_fifths[MAX_CIRCLE_STATIONS];
 


### PR DESCRIPTION
A few global variables were being used without being initialized first, so we just force it to be have zero/default values.

Detected by valgrind when updating the plugin for Cardinal.


```
[dpf] >>>>>>>>>>>>>>>>> LOADING module PS-PurrSoftware : ModeScaleQuant
==164445== Conditional jump or move depends on uninitialised value(s)
==164445==    at 0x773C5E3: __strcpy_chk (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==164445==    by 0x1DA7168: strcpy (string_fortified.h:90)
==164445==    by 0x1DA7168: copyHarmonyTypeToActiveHarmonyType (MSQ_data_and_functions.hpp:497)
==164445==    by 0x1DA7168: ModeScaleQuantMusicStructuresInitialize (MSQ_data_and_functions.hpp:509)
==164445==    by 0x1DA7168: ModeScaleQuant::ModeScaleQuant() (ModeScaleQuant.cpp:953)
==164445==    by 0x1DA944F: rack::CardinalPluginModel<ModeScaleQuant, ModeScaleQuantWidget>::createModule() (helpers.hpp:57)
==164445==    by 0xB86D0F: CardinalDISTRHO::CardinalUI::uiIdle() (CardinalUI.cpp:568)
==164445==    by 0xBA5A43: plugin_idle (DistrhoUIInternal.hpp:231)
==164445==    by 0xBA5A43: CardinalDISTRHO::runSelfTests() (DistrhoPluginJACK.cpp:901)
==164445==    by 0xA20FB8: main (DistrhoPluginJACK.cpp:1014)
==164445==  Uninitialised value was created by a heap allocation
==164445==    at 0x7734E63: operator new(unsigned long) (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==164445==    by 0x1DA9444: rack::CardinalPluginModel<ModeScaleQuant, ModeScaleQuantWidget>::createModule() (helpers.hpp:57)
==164445==    by 0xB86D0F: CardinalDISTRHO::CardinalUI::uiIdle() (CardinalUI.cpp:568)
==164445==    by 0xBA5A43: plugin_idle (DistrhoUIInternal.hpp:231)
==164445==    by 0xBA5A43: CardinalDISTRHO::runSelfTests() (DistrhoPluginJACK.cpp:901)
==164445==    by 0xA20FB8: main (DistrhoPluginJACK.cpp:1014)
==164445== 


==164445== Conditional jump or move depends on uninitialised value(s)
==164445==    at 0x773C5E3: __strcpy_chk (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==164445==    by 0x1DA7181: strcpy (string_fortified.h:90)
==164445==    by 0x1DA7181: copyHarmonyTypeToActiveHarmonyType (MSQ_data_and_functions.hpp:498)
==164445==    by 0x1DA7181: ModeScaleQuantMusicStructuresInitialize (MSQ_data_and_functions.hpp:509)
==164445==    by 0x1DA7181: ModeScaleQuant::ModeScaleQuant() (ModeScaleQuant.cpp:953)
==164445==    by 0x1DA944F: rack::CardinalPluginModel<ModeScaleQuant, ModeScaleQuantWidget>::createModule() (helpers.hpp:57)
==164445==    by 0xB86D0F: CardinalDISTRHO::CardinalUI::uiIdle() (CardinalUI.cpp:568)
==164445==    by 0xBA5A43: plugin_idle (DistrhoUIInternal.hpp:231)
==164445==    by 0xBA5A43: CardinalDISTRHO::runSelfTests() (DistrhoPluginJACK.cpp:901)
==164445==    by 0xA20FB8: main (DistrhoPluginJACK.cpp:1014)
==164445==  Uninitialised value was created by a heap allocation
==164445==    at 0x7734E63: operator new(unsigned long) (in /usr/lib/x86_64-linux-gnu/valgrind/vgpreload_memcheck-amd64-linux.so)
==164445==    by 0x1DA9444: rack::CardinalPluginModel<ModeScaleQuant, ModeScaleQuantWidget>::createModule() (helpers.hpp:57)
==164445==    by 0xB86D0F: CardinalDISTRHO::CardinalUI::uiIdle() (CardinalUI.cpp:568)
==164445==    by 0xBA5A43: plugin_idle (DistrhoUIInternal.hpp:231)
==164445==    by 0xBA5A43: CardinalDISTRHO::runSelfTests() (DistrhoPluginJACK.cpp:901)
==164445==    by 0xA20FB8: main (DistrhoPluginJACK.cpp:1014)
==164445== 
```